### PR TITLE
Lepton preselection for vertex refit

### DIFF
--- a/plugins/MiniAODRefitVertexProducer.cc
+++ b/plugins/MiniAODRefitVertexProducer.cc
@@ -1,0 +1,133 @@
+/* class MiniAODRefitVertexProducer
+ * EDProducer
+ * This producer is intended to take an existing track collection,
+ * and refit the vertex applying BeamSpot constraint
+ */
+
+#include "VertexRefit/TauRefit/plugins/MiniAODRefitVertexProducer.h"
+
+using namespace reco;
+using namespace edm;
+using namespace std;
+
+MiniAODRefitVertexProducer::MiniAODRefitVertexProducer(const edm::ParameterSet& iConfig):
+	srcCands_(consumes<std::vector<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("srcCands"))),
+	srcLostTracks_(consumes<std::vector<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("srcLostTracks"))),
+	PVTag_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PVTag"))),
+	beamSpotTag_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+	useBeamSpot_(iConfig.getParameter<bool>("useBeamSpot")),
+	useLostCands_(iConfig.getParameter<bool>("useLostCands"))
+
+
+{
+  produces<std::vector<RefitVertex> >();
+}
+
+MiniAODRefitVertexProducer::~MiniAODRefitVertexProducer(){
+}
+
+void MiniAODRefitVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+
+	// Obtain collections
+	edm::Handle<std::vector<pat::PackedCandidate> > PFCands;
+	iEvent.getByToken(srcCands_,PFCands);
+
+	edm::Handle<std::vector<pat::PackedCandidate> > PFLostTracks;
+	iEvent.getByToken(srcLostTracks_,PFLostTracks);
+
+	edm::Handle<reco::VertexCollection> PV;
+	iEvent.getByToken(PVTag_,PV);
+
+	edm::Handle<reco::BeamSpot> beamSpot;
+	iEvent.getByToken(beamSpotTag_,beamSpot);
+	
+	edm::ESHandle<TransientTrackBuilder> transTrackBuilder;
+	iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",transTrackBuilder);
+	
+	reco::Vertex thePV = PV->front();
+
+	// Create a new track collection
+	int vtxIdx=0; // AOD PV
+	
+#if CMSSW_MAJOR_VERSION < 8
+	std::auto_ptr<RefitVertexCollection> VertexCollection_out = std::auto_ptr<RefitVertexCollection>(new RefitVertexCollection);
+#else	
+	std::unique_ptr<RefitVertexCollection> VertexCollection_out = std::auto_ptr<RefitVertexCollection>(new RefitVertexCollection);
+#endif
+	
+	// create the TrackCollection for the current pair
+	//reco::TrackCollection* newTrackCollection(new TrackCollection);
+	std::auto_ptr<reco::TrackCollection> newTrackCollection = std::auto_ptr<reco::TrackCollection>(new TrackCollection);
+	std::vector<reco::TransientTrack> transTracks;
+	
+	TransientVertex transVtx;
+	RefitVertex newPV(thePV); // initialized to the PV
+
+	// loop over the PFCandidates
+	for (std::vector<pat::PackedCandidate>::const_iterator cand = PFCands->begin(); cand != PFCands->end(); ++cand) {
+	  
+	  if (cand->charge()==0 || cand->vertexRef().isNull() ) continue;
+	  if ( !(cand->bestTrack()) ) continue;
+
+	  int key = cand->vertexRef().key();
+	  int quality = cand->pvAssociationQuality();
+	  if (key != vtxIdx ||
+	      (quality != pat::PackedCandidate::UsedInFitTight &&
+	       quality != pat::PackedCandidate::UsedInFitLoose) ) continue;
+	
+	  newTrackCollection->push_back(*(cand->bestTrack()));
+	  
+	} // loop over the PFCandidates
+
+
+	// loop over the PFLostTracks
+	if(useLostCands_){
+	  for (std::vector<pat::PackedCandidate>::const_iterator cand = PFLostTracks->begin(); cand != PFLostTracks->end(); ++cand) {
+	    
+	    if (cand->charge()==0 || cand->vertexRef().isNull() ) continue;
+	    if ( !(cand->bestTrack()) ) continue;
+	
+	    int key = cand->vertexRef().key();
+	    int quality = cand->pvAssociationQuality();
+	    if (key != vtxIdx ||
+		(quality != pat::PackedCandidate::UsedInFitTight &&
+		 quality != pat::PackedCandidate::UsedInFitLoose) ) continue;
+	    
+	    newTrackCollection->push_back(*(cand->bestTrack()));
+	    
+	  } // loop over the PFLostTracks
+	} // if useLostCands==true
+
+
+	// Refit the vertex
+	for (std::vector<reco::Track>::const_iterator iter = newTrackCollection->begin(); iter != newTrackCollection->end(); ++iter){
+	  transTracks.push_back(transTrackBuilder->build(*iter));
+	}
+	bool FitOk(true);
+	if ( transTracks.size() >= 3 ) {
+	  AdaptiveVertexFitter avf;
+	  avf.setWeightThreshold(0.1); //weight per track. allow almost every fit, else --> exception
+	  try {
+	    if ( !useBeamSpot_ ){
+	      transVtx = avf.vertex(transTracks);
+	    } else {
+	      transVtx = avf.vertex(transTracks, *beamSpot);
+	    }
+	  } catch (...) {
+	    FitOk = false;
+	  }
+	} else FitOk = false;
+	if ( FitOk ){
+	  newPV = (RefitVertex)transVtx;
+	  VertexCollection_out->push_back(newPV);
+	} // if FitOk == true
+
+	//if (combinations_.size()==0) VertexCollection_out->push_back((RefitVertex)thePV);
+#if CMSSW_MAJOR_VERSION < 8
+	iEvent.put(VertexCollection_out);
+#else
+	iEvent.put(std::move(VertexCollection_out));
+#endif
+	
+}
+DEFINE_FWK_MODULE(MiniAODRefitVertexProducer);

--- a/plugins/MiniAODRefitVertexProducer.h
+++ b/plugins/MiniAODRefitVertexProducer.h
@@ -1,0 +1,88 @@
+#ifndef MiniAODRefitVertexProducer_h
+#define MiniAODRefitVertexProducer_h
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h" 
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h" 
+#include "DataFormats/Common/interface/RefToBase.h"
+
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+
+#include "DataFormats/Common/interface/RefProd.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "VertexRefit/TauRefit/interface/RefitVertex.h"
+
+#include <memory>
+#include <boost/foreach.hpp>
+#include <TFormula.h>
+
+
+using namespace reco;
+using namespace edm;
+using namespace std;
+
+
+
+
+class MiniAODRefitVertexProducer : public EDProducer {
+	public:
+		enum Alg{useInputPV=0, useFontPV};
+
+		explicit MiniAODRefitVertexProducer(const edm::ParameterSet& iConfig);
+		~MiniAODRefitVertexProducer();
+
+		virtual void produce(edm::Event&,const edm::EventSetup&);
+
+		typedef std::vector<edm::InputTag> vInputTag;
+
+
+
+	private:
+		void doCombinations(int offset, int k);
+
+		edm::EDGetTokenT<std::vector<pat::PackedCandidate> > srcCands_;
+		edm::EDGetTokenT<std::vector<pat::PackedCandidate> > srcLostTracks_;
+		edm::EDGetTokenT<reco::VertexCollection > PVTag_;
+		edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_;
+		bool useBeamSpot_;
+		bool useLostCands_;
+	
+};
+
+
+#endif

--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+filteredMuons = cms.EDFilter("PATMuonSelector",
+                             src = cms.InputTag("slimmedMuons"),
+                             cut = cms.string("pt > 20 && " + "abs(eta) < 2.4" +
+                                              " && isGlobalMuon"+
+                                              " && (pfIsolationR04.sumChargedHadronPt+max(0.,(pfIsolationR04.sumNeutralHadronEt+pfIsolationR04.sumPhotonEt-0.5*pfIsolationR04.sumPUPt)))/pt < 0.3"
+                                              )
+                             )
+filteredElectrons = cms.EDFilter("PATElectronSelector",
+                                 src = cms.InputTag("slimmedElectrons"),
+                                 cut = cms.string("pt > 20 && " + "abs(eta) < 2.4"+
+                                                  " && (pfIsolationVariables.sumChargedHadronPt+max(0.,(pfIsolationVariables.sumNeutralHadronEt+pfIsolationVariables.sumPhotonEt-0.5*pfIsolationVariables.sumPUPt)))/pt < 0.3"
+                                                  )
+                                 )
+filteredTaus = cms.EDFilter("PATTauSelector",
+                            src = cms.InputTag("NewTauIDsEmbedded"),
+                            cut = cms.string("tauID('decayModeFindingNewDMs') > 0.5" +
+                                             " && tauID('byVLooseIsolationMVArun2017v2DBnewDMwLT2017') > 0.5"
+                                             )
+                            )
+

--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -20,3 +20,10 @@ filteredTaus = cms.EDFilter("PATTauSelector",
                                              )
                             )
 
+from VertexRefit.TauRefit.AdvancedRefitVertexProducer_cfi import *
+AdvancedRefitVertexBSProducer.srcTaus = cms.InputTag("filteredTaus")
+AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
+AdvancedRefitVertexBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexBSProducer)
+AdvancedRefitVertexNoBSProducer.srcTaus = cms.InputTag("filteredTaus") 
+AdvancedRefitVertexNoBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
+AdvancedRefitVertexNoBSBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexNoBSProducer)

--- a/python/MiniAODRefitVertexProducer_cfi.py
+++ b/python/MiniAODRefitVertexProducer_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+MiniAODRefitVertexBSProducer = cms.EDProducer(
+	"MiniAODRefitVertexProducer",
+	srcCands = cms.InputTag("packedPFCandidates"),
+	srcLostTracks = cms.InputTag("lostTracks"),
+	PVTag = cms.InputTag("offlineSlimmedPrimaryVertices"),
+	beamSpot = cms.InputTag("offlineBeamSpot"),
+	useBeamSpot = cms.bool(True),
+	useLostCands = cms.bool(True)
+)
+
+MiniAODRefitVertexNoBSProducer = cms.EDProducer(
+	"MiniAODRefitVertexProducer",
+	srcCands = cms.InputTag("packedPFCandidates"),
+	srcLostTracks = cms.InputTag("lostTracks"),
+	PVTag = cms.InputTag("offlineSlimmedPrimaryVertices"),
+	beamSpot = cms.InputTag("offlineBeamSpot"),
+	useBeamSpot = cms.bool(False),
+	useLostCands = cms.bool(True)
+)
+
+MiniAODRefitVertexBS = cms.Sequence(MiniAODRefitVertexBSProducer)
+MiniAODRefitVertexNoBS = cms.Sequence(MiniAODRefitVertexNoBSProducer)


### PR DESCRIPTION
Added preselection to leptons that are input to the refitted vertices excluding tau tracks, to reduce ntuple processing time and size. Also, there is a code to produce a collection of regular vertices with BeamSpot  constraint. This collection is not saved in MiniAOD events. 