### PR TITLE
Update on lepton preselection

### DIFF
--- a/plugins/AdvancedRefitVertexProducer.cc
+++ b/plugins/AdvancedRefitVertexProducer.cc
@@ -23,8 +23,8 @@ AdvancedRefitVertexProducer::AdvancedRefitVertexProducer(const edm::ParameterSet
 	deltaRThreshold(iConfig.getParameter<double>("deltaRThreshold")),
 	deltaPtThreshold(iConfig.getParameter<double>("deltaPtThreshold")),
 	useBeamSpot_(iConfig.getParameter<bool>("useBeamSpot")),
-	useLostCands_(iConfig.getParameter<bool>("useLostCands"))
-
+	useLostCands_(iConfig.getParameter<bool>("useLostCands")),
+	excludeFullyLeptonic_(iConfig.getUntrackedParameter<bool>("excludeFullyLeptonic", false))
 
 {
 	vInputTag srcLeptonsTags = iConfig.getParameter<vInputTag>("srcLeptons");
@@ -109,6 +109,11 @@ void AdvancedRefitVertexProducer::produce(edm::Event& iEvent, const edm::EventSe
 	
 	// loop over the pairs in combinations_
 	for (std::vector<std::vector<edm::Ptr<reco::Candidate>>>::const_iterator pair = combinations_.begin(); pair != combinations_.end(); ++pair) {
+
+	  //exclude ee, mm, em pairs if fully leptonic is not considered. 
+	  if(excludeFullyLeptonic_ && 
+	     (std::abs(pair->at(0)->pdgId())==11 || std::abs(pair->at(0)->pdgId())==13) &&
+	     (std::abs(pair->at(1)->pdgId())==11 || std::abs(pair->at(1)->pdgId())==13)) continue;
 
 		// create the TrackCollection for the current pair
 		//reco::TrackCollection* newTrackCollection(new TrackCollection);

--- a/plugins/AdvancedRefitVertexProducer.h
+++ b/plugins/AdvancedRefitVertexProducer.h
@@ -87,7 +87,8 @@ class AdvancedRefitVertexProducer : public EDProducer {
 		double deltaPtThreshold;
 		bool useBeamSpot_;
 		bool useLostCands_;
-	
+		bool excludeFullyLeptonic_;
+
 		std::vector<edm::EDGetTokenT<reco::CandidateView> > srcLeptons_;
 		std::vector<edm::Ptr<reco::Candidate> > allLeptons_;
 		std::vector<std::vector<edm::Ptr<reco::Candidate> > > combinations_;

--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -16,7 +16,7 @@ filteredElectrons = cms.EDFilter("PATElectronSelector",
 filteredTaus = cms.EDFilter("PATTauSelector",
                             src = cms.InputTag("NewTauIDsEmbedded"),
                             cut = cms.string("tauID('decayModeFindingNewDMs') > 0.5" +
-                                             " && tauID('byVLooseIsolationMVArun2017v2DBnewDMwLT2017') > 0.5"
+                                             " && (tauID('byVLooseIsolationMVArun2017v2DBnewDMwLT2017') > 0.5 || tauID('byVVLooseDeepTau2017v2p1VSjet') > 0.5)"
                                              )
                             )
 

--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -21,9 +21,9 @@ filteredTaus = cms.EDFilter("PATTauSelector",
                             )
 
 from VertexRefit.TauRefit.AdvancedRefitVertexProducer_cfi import *
-AdvancedRefitVertexBSProducer.srcTaus = cms.InputTag("filteredTaus")
 AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
+AdvancedRefitVertexBSProducer.excludeFullyLeptonic = cms.untracked.bool(False)
 AdvancedRefitVertexBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexBSProducer)
-AdvancedRefitVertexNoBSProducer.srcTaus = cms.InputTag("filteredTaus") 
 AdvancedRefitVertexNoBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
+AdvancedRefitVertexNoBSProducer.excludeFullyLeptonic = cms.untracked.bool(False)
 AdvancedRefitVertexNoBSBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexNoBSProducer)


### PR DESCRIPTION
Added a flag to exclude refitting of vertex for ee, mumu, and emu pairs if the analysis is not using these channels. Added an OR of VLooseMVAv2 ID and VVLoose DeepTauIDv2 for tau preselection. 