### PR TITLE
Relaxed lepton preselection

### DIFF
--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -22,8 +22,8 @@ filteredTaus = cms.EDFilter("PATTauSelector",
 
 from VertexRefit.TauRefit.AdvancedRefitVertexProducer_cfi import *
 AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
-AdvancedRefitVertexBSProducer.excludeFullyLeptonic = cms.untracked.bool(False)
+AdvancedRefitVertexBSProducer.excludeFullyLeptonic = cms.untracked.bool(True)
 AdvancedRefitVertexBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexBSProducer)
 AdvancedRefitVertexNoBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
-AdvancedRefitVertexNoBSProducer.excludeFullyLeptonic = cms.untracked.bool(False)
+AdvancedRefitVertexNoBSProducer.excludeFullyLeptonic = cms.untracked.bool(True)
 AdvancedRefitVertexNoBSBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexNoBSProducer)

--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -2,21 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 filteredMuons = cms.EDFilter("PATMuonSelector",
                              src = cms.InputTag("slimmedMuons"),
-                             cut = cms.string("pt > 20 && " + "abs(eta) < 2.4" +
-                                              " && isGlobalMuon"+
-                                              " && (pfIsolationR04.sumChargedHadronPt+max(0.,(pfIsolationR04.sumNeutralHadronEt+pfIsolationR04.sumPhotonEt-0.5*pfIsolationR04.sumPUPt)))/pt < 0.3"
-                                              )
+                             cut = cms.string("pt > 20 && " + "abs(eta) < 2.4")
                              )
 filteredElectrons = cms.EDFilter("PATElectronSelector",
                                  src = cms.InputTag("slimmedElectrons"),
-                                 cut = cms.string("pt > 20 && " + "abs(eta) < 2.4"+
-                                                  " && (pfIsolationVariables.sumChargedHadronPt+max(0.,(pfIsolationVariables.sumNeutralHadronEt+pfIsolationVariables.sumPhotonEt-0.5*pfIsolationVariables.sumPUPt)))/pt < 0.3"
-                                                  )
+                                 cut = cms.string("pt > 20 && " + "abs(eta) < 2.4")
                                  )
 filteredTaus = cms.EDFilter("PATTauSelector",
                             src = cms.InputTag("NewTauIDsEmbedded"),
                             cut = cms.string("tauID('decayModeFindingNewDMs') > 0.5" +
-                                             " && (tauID('byVLooseIsolationMVArun2017v2DBnewDMwLT2017') > 0.5 || tauID('byVVLooseDeepTau2017v2p1VSjet') > 0.5)"
+                                             " && (tauID('byVVLooseIsolationMVArun2017v2DBoldDMwLT2017') > 0.5 || tauID('byVVVLooseDeepTau2017v2p1VSjet') > 0.5)"
                                              )
                             )
 

--- a/python/LeptonPreSelections_cfi.py
+++ b/python/LeptonPreSelections_cfi.py
@@ -22,8 +22,8 @@ filteredTaus = cms.EDFilter("PATTauSelector",
 
 from VertexRefit.TauRefit.AdvancedRefitVertexProducer_cfi import *
 AdvancedRefitVertexBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
-AdvancedRefitVertexBSProducer.excludeFullyLeptonic = cms.untracked.bool(True)
+AdvancedRefitVertexBSProducer.excludeFullyLeptonic = cms.untracked.bool(False)
 AdvancedRefitVertexBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexBSProducer)
 AdvancedRefitVertexNoBSProducer.srcLeptons = cms.VInputTag(cms.InputTag("filteredElectrons"), cms.InputTag("filteredMuons"), cms.InputTag("filteredTaus"))
-AdvancedRefitVertexNoBSProducer.excludeFullyLeptonic = cms.untracked.bool(True)
+AdvancedRefitVertexNoBSProducer.excludeFullyLeptonic = cms.untracked.bool(False)
 AdvancedRefitVertexNoBSBSSequence = cms.Sequence(filteredMuons*filteredElectrons*filteredTaus*AdvancedRefitVertexNoBSProducer)


### PR DESCRIPTION
The lepton preselection is relaxed according to suggestion from Daniel. 
The ID and isolation criteria for electron and muons are removed. 
The tau ID criteria are set to lowest MVA/DeepTau isolations.